### PR TITLE
Fix logger deprecation

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -249,7 +249,7 @@ module RightAws
       @params[:connection_lifetime] ||= 20*60
       @params[:api_version]  ||= service_info[:default_api_version]
       @logger = @params[:logger]
-      @logger = ::Rails.logger       if !@logger && defined?(::Rails) && Rails.respond_to?(:logger)
+      @logger = ::Rails.logger       if !@logger && defined?(::Rails) && ::Rails.respond_to?(:logger)
       @logger = RAILS_DEFAULT_LOGGER if !@logger && defined?(RAILS_DEFAULT_LOGGER)
       @logger = Logger.new(STDOUT)   if !@logger
       @logger.info "New #{self.class.name} using #{@params[:connections]} connections mode"


### PR DESCRIPTION
This trivial patch prefers ::Rails.logger to RAILS_DEFAULT_LOGGER. It fixes the deprecation warning in modern rails versions (>= 2.3.9 or so).
