### PR TITLE
Handle lack of bundler in rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # -*- ruby -*-
 
 require 'rubygems'
-require 'bundler'
 require "rake/testtask"
 require 'rcov/rcovtask'
 require 'rake/gempackagetask'
@@ -9,7 +8,13 @@ require 'rake/clean'
 $: << File.dirname(__FILE__)
 testglobs =     ["test/ts_right_aws.rb"]
 
-Bundler::GemHelper.install_tasks
+begin
+  require 'bundler'
+rescue LoadError => e
+  STDERR.puts("Bundler is not available, some rake tasks will not be defined: #{e.message}")
+else
+  Bundler::GemHelper.install_tasks
+end
 
 # == Gem == #
 


### PR DESCRIPTION
Hi,

This patch makes it possible to execute other tasks when bundler is not installed. I just need to build packages and that seems to work without bundler.

Rich
