### PR TITLE
Allow access to another user's buckets

### DIFF
--- a/lib/s3/right_s3.rb
+++ b/lib/s3/right_s3.rb
@@ -99,8 +99,7 @@ module RightAws
     def bucket(name, create=false, perms=nil, headers={})
       headers['x-amz-acl'] = perms if perms
       @interface.create_bucket(name, headers) if create
-      buckets.each { |bucket| return bucket if bucket.name == name }
-      nil
+      Bucket.new(self, name)
     end
     
 


### PR DESCRIPTION
now bucket opening code has logic like "list all our buckets and return one with matching name".
this effectively prevents access to public buckets and buckets that are available via acl
