### PR TITLE
Read from user_data object if it's readable (e.g. a file) before passing 

### DIFF
--- a/lib/ec2/right_ec2_instances.rb
+++ b/lib/ec2/right_ec2_instances.rb
@@ -240,7 +240,13 @@ module RightAws
       params.merge!(amazonize_block_device_mappings(options[:block_device_mappings]))
       # KD: https://github.com/rightscale/right_aws/issues#issue/11
       # Do not modify user data and pass it as is: one may pass there a hex-binary data
-      options[:user_data] = options[:user_data].to_s
+      if options[:user_data].respond_to?(:read)
+        f = options[:user_data]
+        options[:user_data] = f.read(16384)   # max allowed; should adjust for base 64 encoding?
+        f.close
+      else
+        options[:user_data] = options[:user_data].to_s
+      end
       unless options[:user_data].empty?
         # Do not use CGI::escape(encode64(...)) as it is done in Amazons EC2 library.
         # Amazon 169.254.169.254 does not like escaped symbols!


### PR DESCRIPTION
Read from user_data object if it's readable (e.g. a file) before passing it to EC2

Signed-off-by: Craig S. Cottingham craig.cottingham@gmail.com
