### PR TITLE
S3::Bucket#keys_and_services is failure on ruby1.9

### DIFF
--- a/lib/s3/right_s3.rb
+++ b/lib/s3/right_s3.rb
@@ -220,18 +220,19 @@ module RightAws
         #
       def keys_and_service(options={}, head=false)
         opt = {}; options.each{ |key, value| opt[key.to_s] = value }
-        thislist = {}
-        list = []
-        @s3.interface.incrementally_list_bucket(@name, opt) do |thislist|
-          thislist[:contents].each do |entry|
+        service = {}
+        keys = []
+        @s3.interface.incrementally_list_bucket(@name, opt) do |_service|
+          service = _service
+          service[:contents].each do |entry|
             owner = Owner.new(entry[:owner_id], entry[:owner_display_name])
             key = Key.new(self, entry[:key], nil, {}, {}, entry[:last_modified], entry[:e_tag], entry[:size], entry[:storage_class], owner)
             key.head if head
-            list << key
+            keys << key
           end
         end
-        thislist.delete(:contents)
-        [list, thislist]
+        service.delete(:contents)
+        [keys, service]
       end
 
         # Retrieve key information from Amazon. 


### PR DESCRIPTION
For your reference, the problem is a difference in variable's scope between 1.8 and 1.9 like as:

``` ruby
x=nil
10.times {|x|}
puts x # => 9 (on ruby1.8), nil (on ruby1.9)
```
