### PR TITLE
Correcting invalid documentation on Bucket#get method.

### DIFF
--- a/lib/s3/right_s3.rb
+++ b/lib/s3/right_s3.rb
@@ -272,12 +272,12 @@ module RightAws
         key.put(data, perms, headers)
       end
 
-        # Retrieve object data from Amazon. 
+        # Retrieve data object from Amazon. 
         # The +key+ is a +String+ or Key. 
-        # Returns Key instance. 
+        # Returns String instance. 
         #
-        #  key = bucket.get('logs/today/1.log') #=> 
-        #  puts key.data #=> 'sasfasfasdf'
+        #  data = bucket.get('logs/today/1.log') #=> 
+        #  puts data #=> 'sasfasfasdf'
         #
       def get(key, headers={})
         key = Key.create(self, key.to_s) unless key.is_a?(Key)


### PR DESCRIPTION
The Bucket#get method is returning a String that represents data, but the documentation was saying that it is returning a key. Here is a correction.
