### PR TITLE
SimpleDB should support a ConsistentRead argument to get_attributes

### DIFF
--- a/lib/sdb/right_sdb_interface.rb
+++ b/lib/sdb/right_sdb_interface.rb
@@ -33,7 +33,7 @@ module RightAws
     DEFAULT_PORT      = 443
     DEFAULT_PROTOCOL  = 'https'
     DEFAULT_PATH      = '/'
-    API_VERSION       = '2007-11-07'
+    API_VERSION       = '2009-04-15'
     DEFAULT_NIL_REPRESENTATION = 'nil'
 
     @@bench = AwsBenchmarkingBlock.new


### PR DESCRIPTION
This commit implements this small but important feature missing from the main rightscale repo.  

Read about the feature here:   http://docs.amazonwebservices.com/AmazonSimpleDB/latest/DeveloperGuide/index.html?ConsistencySummary.html

Thanks.

PS.  Sorry about the lack of test(s); the testing structure seems a bit rigid.
