### PR TITLE
Document block device mapping syntax for ephemeral storage

### DIFF
--- a/lib/ec2/right_ec2_images.rb
+++ b/lib/ec2/right_ec2_images.rb
@@ -162,7 +162,9 @@ module RightAws
     #                       :root_device_name => "/dev/sda1",
     #                       :block_device_mappings => [ { :ebs_snapshot_id=>"snap-7360871a",
     #                                                     :ebs_delete_on_termination=>true,
-    #                                                     :device_name=>"/dev/sda1"} ] }
+    #                                                     :device_name=>"/dev/sda1"},
+    #                                                   { :virtual_name => 'ephemeral0',}
+    #                                                     :device_name=>"/dev/sdb"} ]
     #  ec2.register_image(image_reg_params) #=> "ami-b2a1f7a4"
     #
     def register_image(options)


### PR DESCRIPTION
Based on http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/index.html?Using_AddingDefaultLocalInstanceStorageToAMI.html.

I have been unsuccessful in _reading_ the ephemeral block device mapping back (in either describe_images, describe_instances calls or in aws console - they all seem to be completely ignoring the ephemeral mapping) but when I launched the image I did get a /dev/sdb in it.

Edit: changed sdc to sdb in the documentation as that's what you get by default with instance storage.
