### PR TITLE
This is SUDO code (never executed) but serves as a suggested change. AWS...

### DIFF
--- a/lib/s3/right_s3.rb
+++ b/lib/s3/right_s3.rb
@@ -98,9 +98,8 @@ module RightAws
     #
     def bucket(name, create=false, perms=nil, headers={})
       headers['x-amz-acl'] = perms if perms
-      @interface.create_bucket(name, headers) if create
-      buckets.each { |bucket| return bucket if bucket.name == name }
-      nil
+      return @interface.create_bucket(name, headers) if create
+      Bucket.new(self, name)
     end
     
 


### PR DESCRIPTION
... has more granular permissions these days and accounts that do not have permission to "list buckets" cannot use said bucket method because it instantiated and loops through all buckets and fails with an authentication error.
