### PR TITLE
Signature error

### DIFF
--- a/lib/s3/right_s3_interface.rb
+++ b/lib/s3/right_s3_interface.rb
@@ -949,7 +949,7 @@ module RightAws
       else
         response_params = ''
       end
-      generate_link('GET', headers.merge(:url=>"#{bucket}/#{CGI::escape key}#{response_params}"), expires)
+      generate_link('GET', headers.merge(:url=>"#{bucket}/#{URI::escape key}#{response_params}"), expires)
     rescue
       on_exception
     end


### PR DESCRIPTION
Escaping the path to sign gives the wrong signature when the key
contains charaters that would be encoded when signed.

https://github.com/rightscale/right_aws/pull/63#issuecomment-1235867

This issue was raised a while ago and closed.
