### PR TITLE
Single-threaded multipart upload support

### DIFF
--- a/lib/s3/right_s3_interface.rb
+++ b/lib/s3/right_s3_interface.rb
@@ -26,6 +26,8 @@ module RightAws
   class S3Interface < RightAwsBase
     
     USE_100_CONTINUE_PUT_SIZE = 1_000_000
+    MINIMUM_PART_SIZE         = 5 * 1024 * 1024
+    DEFAULT_RETRY_COUNT       = 5
     
     include RightAwsBaseInterface
     
@@ -41,13 +43,16 @@ module RightAws
     S3_REQUEST_PARAMETERS = [ 'acl',
         'location',
         'logging', # this one is beta, no support for now
+        'partNumber',
         'response-content-type',
         'response-content-language',
         'response-expires',
         'response-cache-control',
         'response-content-disposition',
         'response-content-encoding',
-        'torrent' ].sort
+        'torrent',
+        'uploadId',
+        'uploads'].sort
 
 
     @@bench = AwsBenchmarkingBlock.new
@@ -524,6 +529,134 @@ module RightAws
       r[:verified_md5] ? (return r) : (raise AwsError.new("Uploaded object failed MD5 checksum verification: #{r.inspect}"))
     end
     
+    # New experimental API for uploading objects using the multipart upload API.
+    # store_object_multipart is similar in function to the store_object method, but breaks the input into parts and transmits each
+    # part separately.  The multipart upload API has the benefit of being be able to retransmit a part in isolation without needing to
+    # restart the entire upload.  This makes it ideal for uploading large files over unreliable networks.  It also does not
+    # require the file size to be known before starting the upload, making it useful for stream data as it is created (say via reading a pipe or socket).
+    # The hash of the response headers contains useful information like the location (the URI for the newly created object), bucket, key, and etag).
+    #
+    # The optional argument of :headers allows the caller to specify arbitrary request header values.
+    #
+    # s3.store_object_multipart(:bucket => "foobucket", :key => "foo", :data => "polemonium" )
+    #   => {:location=>"https://s3.amazonaws.com/right_s3_awesome_test_bucket_000B1_officedrop/test%2Flarge_multipart_file",
+    #       :e_tag=>"\"72b81ac08aed4d4d1055c11f56c2a258-1\"",
+    #       :key=>"test/large_multipart_file",
+    #       :bucket=>"right_s3_awesome_test_bucket_000B1_officedrop"}
+    #
+    # f = File.new("some_file", "r")
+    # s3.store_object_multipart(:bucket => "foobucket", :key => "foo", :data => f )
+    #   => {:location=>"https://s3.amazonaws.com/right_s3_awesome_test_bucket_000B1_officedrop/test%2Flarge_multipart_file",
+    #       :e_tag=>"\"72b81ac08aed4d4d1055c11f56c2a258-1\"",
+    #       :key=>"test/large_multipart_file",
+    #       :bucket=>"right_s3_awesome_test_bucket_000B1_officedrop"}
+    def store_object_multipart(params)
+      AwsUtils.allow_only([:bucket, :key, :data, :headers, :part_size, :retry_count], params)
+      AwsUtils.mandatory_arguments([:bucket, :key, :data], params)
+      params[:headers] = {} unless params[:headers]
+
+      params[:data].binmode if(params[:data].respond_to?(:binmode)) # On Windows, if someone opens a file in text mode, we must reset it to binary mode for streaming to work properly
+
+      # detect whether we are using straight read or converting to string first
+      unless(params[:data].respond_to?(:read))
+        params[:data] = StringIO.new(params[:data].to_s)
+      end
+
+      # make sure part size is > 5 MB minimum
+      params[:part_size] ||= MINIMUM_PART_SIZE
+      if params[:part_size] < MINIMUM_PART_SIZE
+        raise AwsError.new("Part size for a multipart upload must be greater than or equal to #{5 * 1024 * 1024} bytes.  #{params[:part_size]} bytes was provided.")
+      end
+
+      # make sure retry_count is positive
+      params[:retry_count] ||= DEFAULT_RETRY_COUNT
+      if params[:retry_count] < 0
+        raise AwsError.new("Retry count must be positive.  #{params[:retry_count]} bytes was provided.")
+      end
+
+      # Set 100-continue for large part sizes
+      if (params[:part_size] >= USE_100_CONTINUE_PUT_SIZE)
+        params[:headers]['expect'] = '100-continue'
+      end
+
+      # initiate upload
+      initiate_hash = generate_rest_request('POST', params[:headers].merge(:url=>"#{params[:bucket]}/#{CGI::escape params[:key]}?uploads"))
+      initiate_resp = request_info(initiate_hash, S3MultipartUploadInitiateResponseParser.new)
+      upload_id = initiate_resp[:upload_id]
+
+      # split into parts and upload each one, re-trying if necessary
+      #   upload occurs serially at this time.
+      part_etags = []
+      part_data = ""
+      index = 1
+      until params[:data].eof?
+        part_data = params[:data].read(params[:part_size])
+        unless part_data.size == 0
+          retry_attempts = 1
+          while true
+            begin
+              send_part_hash = generate_rest_request('PUT', params[:headers].merge({ :url=>"#{params[:bucket]}/#{CGI::escape params[:key]}?partNumber=#{index}&uploadId=#{upload_id}", :data=>part_data } ))
+              send_part_resp = request_info(send_part_hash, S3HttpResponseHeadParser.new)
+              part_etags << {:part_num => index, :etag => send_part_resp['etag']}
+              index += 1
+              break # successful, can move to next part
+            rescue AwsError => e
+              if retry_attempts >= params[:retry_count]
+                raise e
+              else
+                #Hit an error attempting to transmit part, retry until retry_attemts have been exhausted
+                retry_attempts += 1
+              end
+            end
+          end
+        end
+      end
+
+      # assemble complete upload message
+      complete_body = "<CompleteMultipartUpload>"
+      part_etags.each do |part_hash|
+        complete_body << "<Part><PartNumber>#{part_hash[:part_num]}</PartNumber><ETag>#{part_hash[:etag]}</ETag></Part>"
+      end
+      complete_body << "</CompleteMultipartUpload>"
+      complete_req_hash = generate_rest_request('POST', {:url=>"#{params[:bucket]}/#{CGI::escape params[:key]}?uploadId=#{upload_id}", :data => complete_body})
+      return request_info(complete_req_hash, S3CompleteMultipartParser.new)
+    rescue
+      on_exception
+    end
+
+    class S3MultipartUploadInitiateResponseParser < RightAWSParser
+      def reset
+        @result = {}
+      end
+      def headers_to_string(headers)
+        result = {}
+        headers.each do |key, value|
+          value       = value.first if value.is_a?(Array) && value.size<2
+          result[key] = value
+        end
+        result
+      end
+      def tagend(name)
+        case name
+          when 'UploadId'          then @result[:upload_id] = @text
+        end
+      end
+    end
+
+    class S3CompleteMultipartParser < RightAWSParser  # :nodoc:
+      def reset
+        @result = {}
+      end
+      def tagend(name)
+        case name
+          when 'Location' then @result[:location] = @text
+          when 'Bucket'   then @result[:bucket]   = @text
+          when 'Key'      then @result[:key]      = @text
+          when 'ETag'     then @result[:e_tag]    = @text
+        end
+      end
+    end
+
       # Retrieves object data from Amazon. Returns a +hash+  or an exception.
       #
       #  s3.get('my_awesome_bucket', 'log/curent/1.log') #=>

--- a/test/s3/test_right_s3.rb
+++ b/test/s3/test_right_s3.rb
@@ -13,6 +13,8 @@ class TestS3 < Test::Unit::TestCase
     @key1   = 'test/woohoo1/'
     @key2   = 'test1/key/woohoo2'
     @key3   = 'test2/A%B@C_D&E?F+G=H"I'
+    @key4   = 'test/large_multipart_file_string'
+    @key5   = 'test/large_multipart_file_stream'
     @key1_copy =     'test/woohoo1_2'
     @key1_new_name = 'test/woohoo1_3'
     @key2_new_name = 'test1/key/woohoo2_new'
@@ -39,6 +41,26 @@ class TestS3 < Test::Unit::TestCase
     assert @s3.put(@bucket, @key1, RIGHT_OBJECT_TEXT, 'x-amz-meta-family'=>'Woohoo1!'), 'Put bucket fail'
     assert @s3.put(@bucket, @key2, RIGHT_OBJECT_TEXT, 'x-amz-meta-family'=>'Woohoo2!'), 'Put bucket fail'
     assert @s3.put(@bucket, @key3, RIGHT_OBJECT_TEXT, 'x-amz-meta-family'=>'Woohoo3!'), 'Put bucket fail'
+  end
+
+  def test_04_put_multipart_string
+    test_text = ""
+    for i in 1..100000
+      test_text << "Testing test text #{i}\n"
+    end
+    assert @s3.store_object_multipart({:bucket => @bucket, :key => @key4, :data => StringIO.new(test_text)}), 'Put bucket multipart fail'
+  end
+
+  def test_04b_store_object_multipart_stream
+    rd, wr = IO.pipe
+    producer = Thread.new(wr) do |out|
+      for i in 1..100000
+        out.write("Testing stream text #{i}\n")
+      end
+      out.close
+    end
+    assert @s3.store_object_multipart({:bucket => @bucket, :key => @key5, :data => rd , :part_size => (20*1024*1024)}), 'Put bucket multipart fail'
+    rd.close
   end
 
   def test_05_get_and_get_object
@@ -74,10 +96,12 @@ class TestS3 < Test::Unit::TestCase
 
   def test_08_keys
     keys = @s3.list_bucket(@bucket).map{|b| b[:key]}
-    assert_equal keys.size, 3, "There should be 3 keys"
+    assert_equal keys.size, 5, "There should be 5 keys"
     assert(keys.include?(@key1))
     assert(keys.include?(@key2))
     assert(keys.include?(@key3))
+    assert(keys.include?(@key4))
+    assert(keys.include?(@key5))
   end
 
   def test_09_copy_key
@@ -140,6 +164,7 @@ class TestS3 < Test::Unit::TestCase
     assert @s3.delete_bucket(@bucket)
     assert !@s3.list_all_my_buckets.map{|bucket| bucket[:name]}.include?(@bucket), "#{@bucket} must not exist"
   end
+
 
 
 


### PR DESCRIPTION
I've attempted to add support for the Amazon S3 Multipart Upload API to right_aws.  My main motivation is that I would like to store the output of a mysqldump call directly to S3 without writing to disk first.  I thought something along the following would be nice:

``` ruby
IO.popen("mysqldump -u root mytestdatabase | gzip") do |pipe|
  key = RightAws::S3::Key.create(bucket, 'mysqldump.sql.gz')
  key.data = pipe
  key.put_multipart(:part_size => 5*1024*1024)
end
```

The multipart upload API does not require you to know the content's full size at the start of transmission, and if a problem is encountered while sending a particular part it can be retried in isolation instead of failing the entire upload.  This can be useful when attempting to send files over unreliable networks.

Before writing this I came across a branch by rgeyer@90df9561 which added support back in January 2011.  His approach looks great and has potential to speed up large file uploads dramatically.  Unfortunately,  it didn't solve my particular use case since it still requires the content size before starting the upload.  I also wonder if the fact that is is multi-threaded is preventing the branch from being merged since a commenter pointed out that right_aws is not thread-safe (I'm not sure if this is still the case).  I used much of the code in that branch here, but took a single-threaded approach, buffering each part of the input then sending within a loop.  The implementation will not be close to as fast as simultaneously uploading multiple pieces at once, but it does allow for transmission to occur immediately (great for reading from pipes or sockets) and to retry failures sending individual parts.
