### PR TITLE
Allow persistent spot requests to be created

### DIFF
--- a/lib/ec2/right_ec2_spot_instances.rb
+++ b/lib/ec2/right_ec2_spot_instances.rb
@@ -234,6 +234,7 @@ module RightAws
                                     :value => Proc.new { !options[:user_data].empty? && Base64.encode64(options[:user_data]).delete("\n") }},
         :group_names           => { :amazonize_list => 'LaunchSpecification.SecurityGroup'},
         :group_ids             => { :amazonize_list => 'LaunchSpecification.SecurityGroupId'},
+        :persistence           => { :name => "Type.1", :value => Proc.new { options[:persistent] ? "persistent" : "one-time" } },
         :block_device_mappings => { :amazonize_bdm  => 'LaunchSpecification.BlockDeviceMapping'})
       link = generate_request("RequestSpotInstances", request_hash)
       request_info(link, QEc2DescribeSpotInstanceParser.new(:logger => @logger))


### PR DESCRIPTION
Added :persistent (boolean) option to spot requests creation. Will create persistent requests (they come back if the instance gets killed) if true.
