### PR TITLE
I fixed issue #94 per the comment -- added force_encoding statement

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -1271,6 +1271,7 @@ module RightAws
         end 
         xml.parse
       else
+        xml_text.force_encoding 'utf-8'
         REXML::Document.parse_stream(xml_text, self)
       end
     end


### PR DESCRIPTION
I had this issue in production and this fixed it for us. 

https://github.com/rightscale/right_aws/issues/94

Change is simple -- xml_text.force_encoding 'utf-8'
