### PR TITLE
Support for "ami_version" added in emr interface

### DIFF
--- a/lib/emr/right_emr_interface.rb
+++ b/lib/emr/right_emr_interface.rb
@@ -124,6 +124,7 @@ module RightAws
       :additional_info => 'AdditionalInfo',
       :log_uri => 'LogUri',
       :name => 'Name',
+      :ami_version => 'AmiVersion',
       # JobFlowInstancesConfig
       :ec2_key_name          => 'Instances.Ec2KeyName',
       :hadoop_version => 'Instances.HadoopVersion',


### PR DESCRIPTION
This will allow users to create jobs for hadoop 0.20.205 with ami_version = "2.0.5"
