### PR TITLE
Add support for Temporary Security Tokens

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -448,6 +448,7 @@ module RightAws
                       "AWSAccessKeyId" => @aws_access_key_id,
                       "Version"        => custom_options[:api_version] || @params[:api_version] }
       service_hash.merge!(options)
+      service_hash["SecurityToken"] = @params[:token] if @params[:token]
       # Sign request options
       service_params = signed_service_params(@aws_secret_access_key, service_hash, http_verb, @params[:host_to_sign], @params[:service])
       # Use POST if the length of the query string is too large

--- a/lib/ec2/right_ec2.rb
+++ b/lib/ec2/right_ec2.rb
@@ -120,6 +120,7 @@ module RightAws
     # * <tt>:logger</tt>: for log messages, default: RAILS_DEFAULT_LOGGER else STDOUT
     # * <tt>:signature_version</tt>:  The signature version : '0','1' or '2'(default)
     # * <tt>:cache</tt>: true/false: caching for: ec2_describe_images, describe_instances,
+    # * <tt>:token</tt>: Option SecurityToken for temporary credentials
     # describe_images_by_owner, describe_images_by_executable_by, describe_availability_zones,
     # describe_security_groups, describe_key_pairs, describe_addresses, 
     # describe_volumes, describe_snapshots methods, default: false.


### PR DESCRIPTION
This has become more useful now that you can assign roles to EC2 instances.

This simple patch adds a SecurityToken field to requests if the Ec2 object has been
initialized with a :token parameter.

See http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/UsingIAM.html#UsingIAMrolesWithAmazonEC2Instances
