### PR TITLE
Incorrect escaping of unicode with ruby 1.9.3

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -52,8 +52,8 @@ module RightAws
     # http://docs.amazonwebservices.com/AmazonSimpleDB/2007-11-07/DeveloperGuide/index.html?REST_RESTAuth.html
     def self.amz_escape(param)
       param = param.flatten.join('') if param.is_a?(Array) # ruby 1.9.x Array#to_s fix
-      param.to_s.gsub(/([^a-zA-Z0-9._~-]+)/n) do
-        '%' + $1.unpack('H2' * $1.size).join('%').upcase
+      param.to_s.gsub(/([^a-zA-Z0-9._~-]+)/u) do
+        '%' + $1.unpack('H2' * $1.bytesize).join('%').upcase
       end
     end
 


### PR DESCRIPTION
Given a param of "document_versions/65/unicode - レミ" amz_escape will incorrectly escape only the first byte of the unicode characters. This is due to $.size returning the strings character length in 1.9 vs the strings byte length. Changing $1.size to $1.bytesize fixes the issue.

The regex change removes the following warning:
/right_aws-3.0.4/lib/awsbase/right_awsbase.rb:50: warning: regexp match /.../n against to UTF-8 string

Code works in both 1.9.3 and 1.8.7.
