### PR TITLE
Select only common S3 request headers when uploading multipart chunks.

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -347,7 +347,7 @@ the source key.
     - #125 - fixes redirect bug in file PUT requests (Cary)
     - some other minor fixes
 
-=== Next
+=== 3.0.5
   Release Notes:
   - Added: API '2012-06-15' support for CreateVolume and DescribeVolumes API calls (to support IOPS)
   - Fixed:
@@ -355,3 +355,4 @@ the source key.
     - S3 multi object delete (https://github.com/rightscale/right_aws/pull/106)
     - Support for "ami_version" added in emr interface (https://github.com/rightscale/right_aws/pull/129)
     - S3: Added block references to several methods (https://github.com/rightscale/right_aws/pull/130)
+    - Some other minor changes

--- a/lib/awsbase/version.rb
+++ b/lib/awsbase/version.rb
@@ -2,7 +2,7 @@ module RightAws #:nodoc:
   module VERSION #:nodoc:
     MAJOR = 3  unless defined?(MAJOR)
     MINOR = 0  unless defined?(MINOR)
-    TINY  = 4  unless defined?(TINY)
+    TINY  = 5  unless defined?(TINY)
 
     STRING = [MAJOR, MINOR, TINY].join('.') unless defined?(STRING)
   end

--- a/lib/s3/right_s3_interface.rb
+++ b/lib/s3/right_s3_interface.rb
@@ -54,6 +54,17 @@ module RightAws
         'uploadId',
         'uploads',
         'delete'].sort
+    S3_COMMON_REQUEST_HEADERS = [
+        'authorization',
+        'content-length',
+        'content-type',
+        'content-md5',
+        'date',
+        'expect',
+        'host',
+        'x-amz-date',
+        'x-amz-security-token'
+    ]
     MULTI_OBJECT_DELETE_MAX_KEYS = 1000
 
     
@@ -597,7 +608,8 @@ module RightAws
           retry_attempts = 1
           while true
             begin
-              send_part_hash = generate_rest_request('PUT', params[:headers].merge({ :url=>"#{params[:bucket]}/#{CGI::escape params[:key]}?partNumber=#{index}&uploadId=#{upload_id}", :data=>part_data } ))
+              send_part_headers = Hash[ params[:headers].select { |k, v| S3_COMMON_REQUEST_HEADERS.include?(k.downcase) } ]
+              send_part_hash = generate_rest_request('PUT', send_part_headers.merge({ :url=>"#{params[:bucket]}/#{CGI::escape params[:key]}?partNumber=#{index}&uploadId=#{upload_id}", :data=>part_data } ))
               send_part_resp = request_info(send_part_hash, S3HttpResponseHeadParser.new)
               part_etags << {:part_num => index, :etag => send_part_resp['etag']}
               index += 1


### PR DESCRIPTION
Included is a patch to get S3 server-side encryption support going with multipart uploads.  After initiating the upload, each multipart chunk was being uploaded with the full `params[:headers]` values, but only a subset of s3 headers are valid for individual chunks.
