### PR TITLE
Do not associate bootstrap_actions to steps when describing job flows

### DIFF
--- a/lib/emr/right_emr_interface.rb
+++ b/lib/emr/right_emr_interface.rb
@@ -623,7 +623,7 @@ module RightAws
           when 'ScriptBootstrapAction'
             @bootstrap_action[:script_bootstrap_action] = @text
           when 'BootstrapActionConfig'
-            @step[:bootstrap_actions] << @bootstrap_action
+            # @step[:bootstrap_actions] << @bootstrap_action
           end
         when %r{/InstanceGroups/member} # no trailing $
           case name


### PR DESCRIPTION
Do not tie bootstrap_actions to steps when describing job flows.  The order of XML elements may place bootstrap actions before steps, thus causing EmrInterface.describe_job_flows to break if there are bootstrap actions present.  Regardless, bootstrap actions are tied to the running jobflow and not the steps.
