### PR TITLE
OpenSSL::Digest::Digest is deprecated; use OpenSSL::Digest

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -26,10 +26,10 @@ module RightAws
   require 'digest/md5'
   
   class AwsUtils #:nodoc:
-    @@digest1   = OpenSSL::Digest::Digest.new("sha1")
+    @@digest1   = OpenSSL::Digest.new("sha1")
     @@digest256 = nil
     if OpenSSL::OPENSSL_VERSION_NUMBER > 0x00908000
-      @@digest256 = OpenSSL::Digest::Digest.new("sha256") rescue nil # Some installation may not support sha256
+      @@digest256 = OpenSSL::Digest.new("sha256") rescue nil # Some installation may not support sha256
     end
 
     def self.utc_iso8601(time)


### PR DESCRIPTION
suppress "Digest::Digest is deprecated; use Digest" warnings in ruby 2.1.0
