### PR TITLE
Update to allow encrypted volumes to be created

### DIFF
--- a/lib/ec2/right_ec2_ebs.rb
+++ b/lib/ec2/right_ec2_ebs.rb
@@ -106,6 +106,7 @@ module RightAws
       if options[:options][:api_version] >= VOLUME_API_VERSION
         hash["VolumeType"] = options[:volume_type] unless options[:volume_type].right_blank?
         hash["Iops"]       = options[:iops]        unless options[:iops].right_blank?
+        hash["Encrypted"]  = options[:encrypted]   unless options[:encrypted].right_blank?
       end
       link = generate_request("CreateVolume", hash, options[:options])
       request_info(link, QEc2CreateVolumeParser.new(:logger => @logger))
@@ -395,6 +396,7 @@ module RightAws
         when 'availabilityZone' then @result[:zone]           = @text ###
         when 'volumeType'       then @result[:volume_type]    = @text
         when 'iops'             then @result[:iops]           = @text
+        when 'encrypted'        then @result[:encrypted]      = @text
         end
       end
       def reset


### PR DESCRIPTION
There currently isn't away to allow the encrypted option to be set on an EBS volume in the create_volume method... 
