### PR TITLE
Ignore nil aws_reason for openstack ec2

### DIFF
--- a/lib/ec2/right_ec2_instances.rb
+++ b/lib/ec2/right_ec2_instances.rb
@@ -37,7 +37,7 @@ module RightAws
         reservation[:instances_set].each do |instance|
           # Parse and remove timestamp from the reason string. The timestamp is of
           # the request, not when EC2 took action, thus confusing & useless...
-          instance[:aws_reason]         = instance[:aws_reason].sub(/\(\d[^)]*GMT\) */, '')
+          instance[:aws_reason]         = instance[:aws_reason].sub(/\(\d[^)]*GMT\) */, '') unless instance[:aws_reason].nil?
           instance[:aws_owner]          = reservation[:aws_owner]
           instance[:aws_reservation_id] = reservation[:aws_reservation_id]
           # Security Groups


### PR DESCRIPTION
Avoid NoMethodError: undefined method `sub' for nil:NilClass when no aws_reason is supplied by openstack implementation of ec2
